### PR TITLE
Fix check for missing weights

### DIFF
--- a/lightgbmlss/distributions/distribution_utils.py
+++ b/lightgbmlss/distributions/distribution_utils.py
@@ -85,7 +85,7 @@ class DistributionClass:
 
         # Weights
         target = data.get_label().reshape(-1, 1)
-        if data.get_weight().all() == None:
+        if data.get_weight() is None:
             # Use 1 as weight if no weights are specified
             weights = np.ones_like(target, dtype=target.dtype)
         else:


### PR DESCRIPTION
Uses `is` rather than `==` or `all()`. Addresses #13 without regression for the case of no weights. This is because numpy arrays have custom comparison methods. In particular, `== None` returns an array. This was addressed by adding `.all()`. But since `get_weight` returns a simple None and not a numpy array when there are no weights, there won't be an `all` method.

```
import numpy as np
a = np.zeros(3) # now a is array([0., 0., 0.])
a == None # compares elementwise, outputs array([False, False, False]), i.e. not boolean
a is None # compares object to object, outputs False
a.all() == None # compares elementwise, outputs False
b = None
b == None # outputs True
b is None # outputs True
b.all() == None # error

# only `is None` provides the correct behavior in both cases
```