### PR TITLE
Add prediction type to return the mean, variance, and mode

### DIFF
--- a/lightgbmlss/model.py
+++ b/lightgbmlss/model.py
@@ -436,6 +436,7 @@ class LightGBMLSS:
                 pred_type: str = "parameters",
                 n_samples: int = 1000,
                 quantiles: list = [0.1, 0.5, 0.9],
+                moments_inference: str = "none",
                 seed: str = 123):
         """
         Function that predicts from the trained model.
@@ -450,6 +451,7 @@ class LightGBMLSS:
             - "quantiles" calculates the quantiles from the predicted distribution.
             - "parameters" returns the predicted distributional parameters.
             - "expectiles" returns the predicted expectiles.
+            - "moments" returns the mean, variance, and (if implemented) mode.
         n_samples : int
             Number of samples to draw from the predicted distribution.
         quantiles : List[float]
@@ -470,6 +472,7 @@ class LightGBMLSS:
                                           pred_type=pred_type,
                                           n_samples=n_samples,
                                           quantiles=quantiles,
+                                          moments_inference=moments_inference,
                                           seed=seed)
 
         return predt_df


### PR DESCRIPTION
The mode is only included if the underlying distribution implements it (e.g. zero-inflated does not). Additionally, this change avoids unnecessary sampling if the prediction type doesn't require it. Raises a ValueError for invalid prediction type for Expectile distribution.